### PR TITLE
Add async memory and retrieval modules

### DIFF
--- a/pro_memory.py
+++ b/pro_memory.py
@@ -1,0 +1,36 @@
+import sqlite3
+import asyncio
+from typing import List
+
+DB_PATH = 'pro_memory.db'
+
+async def init_db() -> None:
+    """Initialize sqlite database."""
+    def _setup():
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute('CREATE TABLE IF NOT EXISTS messages(id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)')
+        conn.commit()
+        conn.close()
+    await asyncio.to_thread(_setup)
+
+async def add_message(content: str) -> None:
+    """Store a message asynchronously."""
+    def _write():
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute('INSERT INTO messages(content) VALUES (?)', (content,))
+        conn.commit()
+        conn.close()
+    await asyncio.to_thread(_write)
+
+async def fetch_recent(limit: int = 5) -> List[str]:
+    """Fetch recent messages for context."""
+    def _read() -> List[str]:
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute('SELECT content FROM messages ORDER BY id DESC LIMIT ?', (limit,))
+        rows = cur.fetchall()
+        conn.close()
+        return [r[0] for r in rows][::-1]
+    return await asyncio.to_thread(_read)

--- a/pro_rag.py
+++ b/pro_rag.py
@@ -1,0 +1,16 @@
+from typing import List
+from pro_metrics import tokenize
+import pro_memory
+
+async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
+    """Retrieve relevant messages from memory based on word overlap."""
+    messages = await pro_memory.fetch_recent(50)
+    qset = set(query_words)
+    scored = []
+    for msg in messages:
+        words = tokenize(msg)
+        score = len(qset.intersection(words))
+        if score:
+            scored.append((score, msg))
+    scored.sort(reverse=True)
+    return [m for _, m in scored[:limit]]

--- a/pro_sequence.py
+++ b/pro_sequence.py
@@ -1,0 +1,13 @@
+from typing import Dict, List
+
+def analyze_sequences(state: Dict, words: List[str]) -> None:
+    """Update state with word and bigram counts."""
+    wc = state.setdefault('word_counts', {})
+    bc = state.setdefault('bigram_counts', {})
+    prev = '<s>'
+    wc[prev] = wc.get(prev, 0) + 1
+    for word in words:
+        wc[word] = wc.get(word, 0) + 1
+        bc.setdefault(prev, {})
+        bc[prev][word] = bc[prev].get(word, 0) + 1
+        prev = word


### PR DESCRIPTION
## Summary
- Introduce SQLite-backed async memory store and retrieval augmented generation
- Enhance engine with async processing and contextual sequence training
- Add sequence analyzer for word and bigram statistics

## Testing
- `python -m py_compile pro_engine.py pro_memory.py pro_rag.py pro_sequence.py pro_metrics.py pro_tune.py && echo 'lint ok'`
- `python - <<'PY'
import asyncio
from pro_engine import ProEngine
async def main():
    e = ProEngine()
    await e.setup()
    resp, metrics = await e.process_message('hello world')
    print('resp:', resp)
    print('metrics:', metrics)
asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd6548c883298c6935a7c96f35c6